### PR TITLE
Fix CSV parser to accept current Nexo 11-column schema (#39)

### DIFF
--- a/src/lib/csv-parser.test.ts
+++ b/src/lib/csv-parser.test.ts
@@ -65,9 +65,9 @@ NXTabc,Liquidation,BTC,-0.01000000,BTC,0.01000000,$800.00,-,-,approved / Liquida
     expect(transactions[0].outputAmount).toBe(800);
   });
 
-  it("rejects CSV with wrong number of columns", () => {
+  it("rejects CSV whose headers do not include required columns", () => {
     const csv = "A,B,C\n1,2,3\n";
-    expect(() => parseCSV(csv)).toThrow("Headers mismatch");
+    expect(() => parseCSV(csv)).toThrow(/missing required column/i);
   });
 
   it("skips empty lines", () => {
@@ -201,5 +201,33 @@ NXT999,Interest,ETH,0.00500000,ETH,0.00500000,$15.00,-,-,approved / ETH Interest
     const csv = `Transaction,Type,Input Currency,Input Amount,Output Currency,Output Amount,USD Equivalent,Fee,Fee Currency,Details,Date / Time (UTC),normalizedDisplayDetails
 NXT001,Interest,BTC,0.00010000,BTC,0.00010000`;
     expect(() => parseCSV(csv)).toThrow();
+  });
+
+  it("parses Nexo's current 11-column schema (no normalizedDisplayDetails)", () => {
+    const csv = `Transaction,Type,Input Currency,Input Amount,Output Currency,Output Amount,USD Equivalent,Fee,Fee Currency,Details,Date / Time (UTC)
+NXT001,Interest,BTC,0.00010000,BTC,0.00010000,$8.00,-,-,approved / BTC Interest,2025-06-01 06:00:00
+`;
+    const transactions = parseCSV(csv);
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].id).toBe("NXT001");
+    expect(transactions[0].usdEquivalent).toBe(8);
+  });
+
+  it("accepts whitespace-padded header names (Excel round-trip)", () => {
+    const csv = ` Transaction , Type , Input Currency , Input Amount , Output Currency , Output Amount , USD Equivalent , Fee , Fee Currency , Details , Date / Time (UTC)
+NXT001,Interest,BTC,0.00010000,BTC,0.00010000,$8.00,-,-,approved / BTC Interest,2025-06-01 06:00:00
+`;
+    const transactions = parseCSV(csv);
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].id).toBe("NXT001");
+  });
+
+  it("accepts CSV with extra unknown columns beyond the required 11", () => {
+    const csv = `Transaction,Type,Input Currency,Input Amount,Output Currency,Output Amount,USD Equivalent,Fee,Fee Currency,Details,Date / Time (UTC),FutureColumn
+NXT001,Interest,BTC,0.00010000,BTC,0.00010000,$8.00,-,-,approved / BTC Interest,2025-06-01 06:00:00,ignored
+`;
+    const transactions = parseCSV(csv);
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].id).toBe("NXT001");
   });
 });

--- a/src/lib/csv-parser.ts
+++ b/src/lib/csv-parser.ts
@@ -2,7 +2,19 @@ import { parse } from "papaparse";
 import type { Transaction } from "../types";
 import { TransactionType } from "../data/transaction-types";
 
-const EXPECTED_COLUMNS = 12;
+const REQUIRED_COLUMNS = [
+  "Transaction",
+  "Type",
+  "Input Currency",
+  "Input Amount",
+  "Output Currency",
+  "Output Amount",
+  "USD Equivalent",
+  "Fee",
+  "Fee Currency",
+  "Details",
+  "Date / Time (UTC)",
+] as const;
 
 type NexoHeaders = {
   "Date / Time (UTC)": string;
@@ -16,7 +28,6 @@ type NexoHeaders = {
   "Transaction": string;
   "Type": string;
   "USD Equivalent": string;
-  "normalizedDisplayDetails": string;
 }
 
 function fixFiatX(cur: string): string {
@@ -31,19 +42,19 @@ function fixFiatX(cur: string): string {
  * Handles EURX/GBPX/USDX normalization, repayment sign flip, and liquidation output fix.
  */
 export function parseCSV(content: string): Transaction[] {
-  const lines = content.split("\n");
-  if (lines.length < 2) {
-    throw new Error("CSV file is empty or has no data rows.");
-  }
-
-  const headers = lines[0].split(",");
-  if (headers.length !== EXPECTED_COLUMNS) {
+  const result = parse<NexoHeaders>(content, {
+    header: true,
+    transformHeader: (h) => h.trim(),
+  });
+  const fields = result.meta.fields ?? [];
+  const missing = REQUIRED_COLUMNS.filter((c) => !fields.includes(c));
+  if (missing.length > 0) {
     throw new Error(
-      `Headers mismatch. Expected ${EXPECTED_COLUMNS}, got ${headers.length}`
+      `CSV is missing required column(s): ${missing.join(", ")}`
     );
   }
 
-  const allData = parse<NexoHeaders>(content, { header: true }).data;
+  const allData = result.data;
   const transactions: Transaction[] = [];
 
   for (const row of allData) {


### PR DESCRIPTION
## Summary

Nexo dropped the `normalizedDisplayDetails` column between March and May 2026. The hardcoded `EXPECTED_COLUMNS = 12` guard in `src/lib/csv-parser.ts` rejected current exports with `Headers mismatch. Expected 12, got 11`, blocking users from uploading their own data.

Replaces the count guard with header-name validation against papaparse's `result.meta.fields`. Accepts any input containing the 11 required columns regardless of count or trailing extras — forward-compatible with future Nexo schema changes.

## Changes

**`src/lib/csv-parser.ts`:**
- Replace `EXPECTED_COLUMNS = 12` with a `REQUIRED_COLUMNS` tuple of the 11 column names actually read.
- Replace the pre-split count check with `result.meta.fields` validation. If any required column is missing, throw a clear error listing them.
- Add `transformHeader: (h) => h.trim()` to handle whitespace-padded headers (Excel round-trip).
- Remove unused `normalizedDisplayDetails` field from the private `NexoHeaders` type.

**`src/lib/csv-parser.test.ts`:**
- Update one existing test (was `rejects CSV with wrong number of columns`, now `rejects CSV whose headers do not include required columns`).
- Add 3 new tests:
  - 11-column May 2026 schema parses successfully (primary acceptance for #39)
  - Whitespace-padded header names accepted via `transformHeader: trim`
  - CSVs with extra unknown columns beyond the required 11 still parse (forward-compat)

## Test plan
- [x] All 90 unit tests pass (was 87, +3 new) — `npm test`
- [x] Production build green — `npm run build`
- [x] Browser smoke: synthetic 11-col CSV uploaded via file dialog, parsed to 10 transactions on dashboard, no parser errors (the 6 CORS errors observed are unrelated `api.frankfurter.app` issues tracked at #40)
- [ ] CI: lint, typecheck, unit-test (×3), build (×3), e2e
- [ ] User verification: upload a real May 2026 Nexo export and confirm dashboard renders

Closes #39