### PR TITLE
Migrate Frankfurter currency API from .app to .dev/v1 (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A privacy-first analytical tool for the [Nexo](https://www.nexo.com) crypto lend
 ## Features
 
 ### Portfolio Analytics
-- Real-time portfolio value via CoinGecko, CryptoCompare, and frankfurter.app
+- Real-time portfolio value via CoinGecko, CryptoCompare, and frankfurter.dev
 - Historic portfolio value chart with daily close prices
 - Portfolio distribution donut chart
 - Performance metrics: Net Invested, Interest Earned, Unrealized P/L
@@ -70,7 +70,7 @@ npm install
 npm run dev
 ```
 
-No external services required. Currency metadata is bundled locally in `src/data/currencies.ts` and price data is fetched from CoinGecko, CryptoCompare, and frankfurter.app at runtime.
+No external services required. Currency metadata is bundled locally in `src/data/currencies.ts` and price data is fetched from CoinGecko, CryptoCompare, and frankfurter.dev at runtime.
 
 ## Scripts
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
 
         {/* Data sources */}
         <p className="text-[1.15rem] text-slate-400 max-w-[48rem] mx-auto">
-          Market data provided by CoinGecko, CryptoCompare, and frankfurter.app.
+          Market data provided by CoinGecko, CryptoCompare, and frankfurter.dev.
         </p>
 
         {/* License */}

--- a/src/hooks/use-fiat-rates.ts
+++ b/src/hooks/use-fiat-rates.ts
@@ -17,14 +17,14 @@ export function useFiatRates() {
     const fetchRates = async () => {
       try {
         if (hasEUR) {
-          const res = await fetch("https://api.frankfurter.app/latest?from=EUR&to=USD");
+          const res = await fetch("https://api.frankfurter.dev/v1/latest?from=EUR&to=USD");
           if (res.ok) {
             const data = await res.json();
             updateFiatRate("EUR", data.rates.USD);
           }
         }
         if (hasGBP) {
-          const res = await fetch("https://api.frankfurter.app/latest?from=GBP&to=USD");
+          const res = await fetch("https://api.frankfurter.dev/v1/latest?from=GBP&to=USD");
           if (res.ok) {
             const data = await res.json();
             updateFiatRate("GBP", data.rates.USD);

--- a/src/hooks/use-historic-prices.ts
+++ b/src/hooks/use-historic-prices.ts
@@ -69,7 +69,7 @@ export function useHistoricPrices() {
         }
       }
 
-      // Fiat: frankfurter.app
+      // Fiat: frankfurter.dev
       for (const symbol of fiatSymbols) {
         if (symbol === "USD") {
           const priceMap = new Map<string, number>();
@@ -78,7 +78,7 @@ export function useHistoricPrices() {
           continue;
         }
         try {
-          const url = `https://api.frankfurter.app/${startDate}..${endDate}?from=${symbol}&to=USD`;
+          const url = `https://api.frankfurter.dev/v1/${startDate}..${endDate}?from=${symbol}&to=USD`;
           const res = await fetch(url);
           if (!res.ok) continue;
           const data = await res.json();


### PR DESCRIPTION
## Summary

Frankfurter moved from `https://api.frankfurter.app/` to `https://api.frankfurter.dev/v1/`. The old domain returns HTTP 301 to a target that fails CORS preflight from the browser, breaking all fiat-rate fetches with `net::ERR_FAILED`. Response shapes are identical between old and new API — drop-in URL replacement, no parsing changes needed.

## Changes

- `src/hooks/use-fiat-rates.ts` — EUR→USD and GBP→USD latest URLs (lines 20, 27)
- `src/hooks/use-historic-prices.ts` — historic date-range URL template literal (line 81) + comment (line 72)
- `src/components/layout/Footer.tsx` — attribution text "frankfurter.app" → "frankfurter.dev" (line 23)
- `README.md` — two attribution mentions (lines 17, 73)

All URLs: `https://api.frankfurter.app/` → `https://api.frankfurter.dev/v1/`

## Test plan

- [x] All 90 unit tests pass — `npm test`
- [x] Production build green — `npm run build`
- [x] Browser smoke: loaded Try Demo on `npm run dev`, **0 console errors** (was 6 CORS errors before this change), 3 successful HTTP 200 responses against `frankfurter.dev/v1/...` URLs verified via the network panel
- [ ] CI: lint, typecheck, unit-test (×3), build (×3), e2e

## Follow-up

A separate PR will add an API-endpoint validity test (env-gated vitest file + nightly cron) covering all five external APIs the app uses (Frankfurter latest + range, CoinGecko, CryptoCompare, rss2json). Designed to catch this kind of API move in the future.

Closes #40