### PR TITLE
v4.1 release prep: version bump + UI/CHANGELOG updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.1.0] - 2026-05-18
+
+### Fixed
+- CSV parser correctly handles commas inside quoted `Details` fields (e.g. `"approved / lidl, berlin"`) by migrating from a hand-rolled parser to papaparse. (#34, #35)
+- CSV parser accepts Nexo's current 11-column export schema. The hardcoded 12-column guard previously rejected exports after Nexo removed the `normalizedDisplayDetails` column in May 2026. Header-name validation against `meta.fields` replaces the count check and accepts both 11- and 12-column schemas. (#39, #46)
+- Live currency rates work again. Migrated the Frankfurter API from the deprecated `api.frankfurter.app` (now 301-redirects with CORS failures) to `api.frankfurter.dev/v1/`. (#40, #47)
+
+### Changed
+- Resolved 11 Dependabot advisories in dev-only toolchain (vite, postcss, lodash, picomatch, @babel/runtime, brace-expansion, ws). Runtime bundle unaffected. (#49)
+- Bumped dev dependencies: react/react-dom 19.2.4 → 19.2.6 (#45), autoprefixer 10.4.27 → 10.5.0 (#43), typescript-eslint 8.57.1 → 8.59.4 (#42).
+- Brand-neutral attribution: "frankfurter.dev" → "Frankfurter" in Footer and README.
+- Removed "Rebuilt from scratch" tagline from the landing-page banner.
+
+### Removed
+- Dead pre-React `html-draw/` mockup folder. (#48)
+
+### Internal
+- Two new regression tests for the papaparse migration: end-of-data sentinel break, and throw-on-malformed-row (no silent swallowing).
+- Three new regression tests for the column-count fix: 11-column schema accepted, whitespace-padded headers handled via `transformHeader: trim`, extra unknown columns ignored.
+
 ## [4.0.0] - 2026-03-22
 
 ### Complete Rebuild

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A privacy-first analytical tool for the [Nexo](https://www.nexo.com) crypto lend
 ## Features
 
 ### Portfolio Analytics
-- Real-time portfolio value via CoinGecko, CryptoCompare, and frankfurter.dev
+- Real-time portfolio value via CoinGecko, CryptoCompare, and Frankfurter
 - Historic portfolio value chart with daily close prices
 - Portfolio distribution donut chart
 - Performance metrics: Net Invested, Interest Earned, Unrealized P/L
@@ -70,7 +70,7 @@ npm install
 npm run dev
 ```
 
-No external services required. Currency metadata is bundled locally in `src/data/currencies.ts` and price data is fetched from CoinGecko, CryptoCompare, and frankfurter.dev at runtime.
+No external services required. Currency metadata is bundled locally in `src/data/currencies.ts` and price data is fetched from CoinGecko, CryptoCompare, and Frankfurter at runtime.
 
 ## Scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexo-ta",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexo-ta",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dependencies": {
         "@fontsource/inter": "^5.2.5",
         "@tanstack/react-table": "^8.21.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexo-ta",
   "private": true,
-  "version": "4.0.0",
+  "version": "4.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -59,7 +59,7 @@ export default function LandingPage() {
         <header className="text-center pt-12 pb-16 animate-in">
           <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-accent/10 border border-accent/20 text-accent text-[1.2rem] font-medium mb-8">
             <span className="w-[6px] h-[6px] rounded-full bg-accent animate-pulse" />
-            Version 4.0 — Rebuilt from scratch
+            Version 4.1
           </div>
           <h1 className="text-[4.4rem] md:text-[5.6rem] font-extrabold tracking-tight text-slate-900 dark:text-white leading-[1.1] mb-6">
             Analyze your Nexo

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
       <div className="max-w-[64rem] mx-auto space-y-8 text-center">
         {/* Links row */}
         <div className="flex flex-wrap items-center justify-center gap-6 text-[1.2rem]">
-          <span className="text-slate-400">Version 4.0</span>
+          <span className="text-slate-400">Version 4.1</span>
           <span className="text-slate-300 dark:text-slate-600">&middot;</span>
           <span className="text-slate-400">&copy; 2021&ndash;2026 bandrewk</span>
           <span className="text-slate-300 dark:text-slate-600">&middot;</span>
@@ -20,7 +20,7 @@ export default function Footer() {
 
         {/* Data sources */}
         <p className="text-[1.15rem] text-slate-400 max-w-[48rem] mx-auto">
-          Market data provided by CoinGecko, CryptoCompare, and frankfurter.dev.
+          Market data provided by CoinGecko, CryptoCompare, and Frankfurter.
         </p>
 
         {/* License */}


### PR DESCRIPTION
## Summary

Stages metadata for v4.1. Pure version/text changes — no code-behavior changes. Once merged to development and promoted to main, this becomes the v4.1.0 release.

## Changes

| File | Change |
|---|---|
| `package.json` | `4.0.0` → `4.1.0` (and lockfile sync) |
| `src/components/landing/LandingPage.tsx:62` | Banner: `Version 4.0 — Rebuilt from scratch` → `Version 4.1` (drops the tagline) |
| `src/components/layout/Footer.tsx:7` | `Version 4.0` → `Version 4.1` |
| `src/components/layout/Footer.tsx:23` | `... and frankfurter.dev.` → `... and Frankfurter.` |
| `README.md:17, 73` | Same brand-neutral attribution swap |
| `CHANGELOG.md` | New `[4.1.0] - 2026-05-18` entry summarizing PRs #34/#35, #39/#46, #40/#47, #42, #43, #45, #48, #49 |

All `https://api.frankfurter.dev/v1/...` URLs in code are unchanged — those are the live API.

## Test plan

- [x] `npm test` → 90/90 pass
- [x] `npm run build` → green, identical bundle size
- [x] `npm run lint` → clean (lint output now reads `nexo-ta@4.1.0`)
- [x] Browser smoke: banner reads "Version 4.1", footer reads "Version 4.1" and "Market data provided by CoinGecko, CryptoCompare, and Frankfurter."
- [ ] CI: lint, typecheck, unit-test (×3), build (×3), e2e

## What this is NOT

- Not the `development` → `main` promotion (separate, follow-up).
- Not the API endpoint validity test PR (separate, design ready).
- Not the lucide-react dependabot ignore rule (separate).
- Not a code-behavior change — no logic touched.

## Out of scope follow-up

The Footer's "GitHub" link is a plain text link with no icon, while LandingPage uses the `Github` icon decoratively. Inconsistency noted, deferred to a future design polish PR. Also: the `Github` icon is the only brand icon used in the codebase, so it's the single blocker to a future lucide-react@1.x migration.